### PR TITLE
Fix installed formula detection

### DIFF
--- a/brew.py
+++ b/brew.py
@@ -50,7 +50,10 @@ class Brew(dotbot.Plugin):
         with open(os.devnull, 'w') as devnull:
             stdin = stdout = stderr = devnull
             for package in packages_list:
-                cmd = "brew --cellar %s" % package
+                if install_cmd == 'brew install':
+                    cmd = "brew ls --versions %s" % package
+                else:
+                    cmd = "brew cask ls --versions %s" % package
                 isInstalled = subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd)
                 if isInstalled != 0:
                     log.info("Installing %s" % package)


### PR DESCRIPTION
It wasn't correctly identifying if the formula is installed. (False positives for regular brews and false negatives for casks.)

Per http://stackoverflow.com/questions/20802320/detect-if-homebrew-package-is-installed#20802425

I'm sure there's a cleaner way of handling the brew vs cask logic, but I'm not a Python programmer, so this works.