### PR TITLE
fix incorrect variable reference

### DIFF
--- a/brew.py
+++ b/brew.py
@@ -78,7 +78,7 @@ class Brew(dotbot.Plugin):
                 result = subprocess.call(cmd, shell=True, cwd=cwd)
 
                 if result != 0:
-                    log.warning('Failed to install file [%s]' % tap)
+                    log.warning('Failed to install file [%s]' % f)
                     return False
             return True
 


### PR DESCRIPTION
Super tiny change here.

`tap` isn't defined in the context of `_install_bundle` so I think a copy/paste typo must have happened here.

Fixed by changing `tap` to `f`.