### PR TITLE
Update dotbot brew to new brew commands and improve defaults

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,21 @@
+name: macOS
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install some package
+      run: ./test emacs
+
+    - name: Test installed package
+      run: brew test emacs

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -8,14 +8,13 @@ on:
 
 jobs:
   build:
-
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Install some package
-      run: ./test emacs
+      - name: Install some package
+        run: ./test emacs vlc
 
-    - name: Test installed package
-      run: brew test emacs
+      - name: Test installed package
+        run: brew test emacs

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macOS
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 jobs:
@@ -18,3 +18,5 @@ jobs:
 
       - name: Test installed package
         run: brew test emacs
+      
+        

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,10 +13,17 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Install some package
-        run: ./test emacs vlc
+      - name: Install some packages
+        run: ./test emacs discord vi homebrew/cask-fonts font-meslo-lg-nerd-font
 
-      - name: Test installed package
+      - name: Test installed brew
         run: brew test emacs
-      
-        
+
+      - name: Test installed cask
+        run: brew test discord
+
+      - name: Test cask installed through Brewfile
+        run: brew test font-meslo-lg-nerd-font
+
+      - name: Test brew installed through Brewfile
+        run: brew test vim

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -17,13 +17,13 @@ jobs:
         run: ./test
 
       - name: Test installed brew
-        run: brew test ack
+        run: brew ls ack
 
       - name: Test installed cask
-        run: brew test gpg-suite
+        run: brew ls --cask gpg-suite
 
       - name: Test cask installed through Brewfile
-        run: brew test firefox
+        run: brew ls --cask firefox
 
       - name: Test brew installed through Brewfile
-        run: brew test jq
+        run: brew ls jq

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -3,7 +3,7 @@ name: macOS
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/README.org
+++ b/README.org
@@ -22,9 +22,13 @@ Modify your =install= script, so it automatically enables =brew= plugin.
 ** Usage
 
 In your =install.conf.yaml= use =brew= directive to list all packages to be
-installed using =brew=. The same works with =cask.= For example:
+installed using =brew=. The same works with =cask= and =brewfile=. For example:
 
 #+BEGIN_SRC yaml
+- brewfile:
+    - Brewfile
+    - brew/Brewfile
+
 - tap:
     - caskroom/fonts
 

--- a/brew.py
+++ b/brew.py
@@ -134,7 +134,7 @@ class Brew(dotbot.Plugin):
     def _bootstrap_brew(self):
         self._log.info("Installing brew")
         link = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
-        cmd = """/bin/bash -c "$(curl -fsSL {0})" """.format(link)
+        cmd = """[[ $(command -v brew) != "" ]] || /bin/bash -c "$(curl -fsSL {0})" """.format(link)
         return subprocess.call(cmd, shell=True, cwd=self._context.base_directory()) == 0
 
     def _bootstrap_cask(self):

--- a/brew.py
+++ b/brew.py
@@ -50,7 +50,7 @@ class Brew(dotbot.Plugin):
         for tap in tap_list:
             log.info("Tapping %s" % tap)
             cmd = "brew tap %s" % (tap)
-            result = self._invoke(cmd, defaults)
+            result = self._invokeShellCommand(cmd, defaults)
             if result != 0:
                 log.warning('Failed to tap [%s]' % tap)
                 return False

--- a/brew.py
+++ b/brew.py
@@ -4,9 +4,10 @@ class Brew(dotbot.Plugin):
     _brewDirective = "brew"
     _caskDirective = "cask"
     _tapDirective = "tap"
+    _brewFileDirective = "brewfile"
 
     def can_handle(self, directive):
-        return directive in (self._tapDirective, self._brewDirective, self._caskDirective)
+        return directive in (self._tapDirective, self._brewDirective, self._caskDirective, self._brewFileDirective)
 
     def handle(self, directive, data):
         if directive == self._tapDirective:
@@ -18,12 +19,14 @@ class Brew(dotbot.Plugin):
         if directive == self._caskDirective:
             self._bootstrap_cask()
             return self._process_data("brew cask install", data)
+        if directive == self._brewFileDirective:
+            self._bootstrap_brew()
+            return self._install_bundle(data)
         raise ValueError('Brew cannot handle directive %s' % directive)
 
     def _tap(self, tap_list):
         cwd = self._context.base_directory()
         log = self._log
-
         with open(os.devnull, 'w') as devnull:
             stdin = stdout = stderr = devnull
             for tap in tap_list:
@@ -62,6 +65,21 @@ class Brew(dotbot.Plugin):
                     if result != 0:
                         log.warning('Failed to install [%s]' % package)
                         return False
+            return True
+
+    def _install_bundle(self, brew_files):
+        cwd = self._context.base_directory()
+        log = self._log
+        with open(os.devnull, 'w') as devnull:
+            stdin = stdout = stderr = devnull
+            for f in brew_files:
+                log.info("Installing from file %s" % f)
+                cmd = "brew bundle --file=%s" % f            
+                result = subprocess.call(cmd, shell=True, cwd=cwd)
+
+                if result != 0:
+                    log.warning('Failed to install file [%s]' % tap)
+                    return False
             return True
 
     def _bootstrap(self, cmd):

--- a/brew.py
+++ b/brew.py
@@ -107,17 +107,15 @@ class Brew(dotbot.Plugin):
         if defaults.get(self._autoBootstrapOption, True) == True:
             self._bootstrap_brew()
             self._bootstrap_cask()
-        with open(os.devnull, 'w') as devnull:
-            stdin = stdout = stderr = devnull
-            for f in brew_files:
-                log.info("Installing from file %s" % f)
-                cmd = "brew bundle --verbose --file=%s" % f
-                result = self._invokeShellCommand(cmd, defaults)
+        stdin = stdout = stderr = devnull
+        for f in brew_files:
+            log.info("Installing from file %s" % f)
+            cmd = "brew bundle --verbose --file=%s" % f
+            result = self._invokeShellCommand(cmd, defaults)
 
-                if result != 0:
-                    log.warning('Failed to install file [%s]' % f)
-                    return False
-            return True
+            if result != 0:
+                log.warning('Failed to install file [%s]' % f)
+                return False
 
     def _installBrew(self, components):
         log = self._log

--- a/brew.py
+++ b/brew.py
@@ -50,7 +50,10 @@ class Brew(dotbot.Plugin):
         with open(os.devnull, 'w') as devnull:
             stdin = stdout = stderr = devnull
             for package in packages_list:
-                cmd = "brew --cellar %s" % package
+                if install_cmd == 'brew install':
+                    cmd = "brew ls --versions %s" % package
+                else:
+                    cmd = "brew cask ls --versions %s" % package
                 isInstalled = subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd)
                 if isInstalled != 0:
                     log.info("Installing %s" % package)

--- a/brew.py
+++ b/brew.py
@@ -75,7 +75,7 @@ class Brew(dotbot.Plugin):
             stdin = stdout = stderr = devnull
             for f in brew_files:
                 log.info("Installing from file %s" % f)
-                cmd = "brew bundle --file=%s" % f            
+                cmd = "brew bundle --verbose --file=%s" % f            
                 result = subprocess.call(cmd, shell=True, cwd=cwd)
 
                 if result != 0:

--- a/brew.py
+++ b/brew.py
@@ -21,6 +21,7 @@ class Brew(dotbot.Plugin):
             return self._process_data("brew cask install", data)
         if directive == self._brewFileDirective:
             self._bootstrap_brew()
+            self._bootstrap_cask()
             return self._install_bundle(data)
         raise ValueError('Brew cannot handle directive %s' % directive)
 

--- a/brew.py
+++ b/brew.py
@@ -12,6 +12,7 @@ class Brew(dotbot.Plugin):
     _brewFileDirective = "brewfile"
 
     _autoBootstrapOption = "auto_bootstrap"
+    _forceIntelOption = "force_intel"
 
     def can_handle(self, directive):
         return directive in (self._installBrewDirective, self._tapDirective, self._brewDirective, self._caskDirective, self._brewFileDirective)
@@ -40,6 +41,8 @@ class Brew(dotbot.Plugin):
                 stdout = None
             if defaults.get('stderr', False) == True:
                 stderr = None
+            if defaults.get(self._forceIntelOption, False) == True:
+                cmd = "arch --x86_64 " + cmd
             return subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr,
                                    cwd=self._context.base_directory())
 

--- a/brew.py
+++ b/brew.py
@@ -93,10 +93,8 @@ class Brew(dotbot.Plugin):
         if platform.system() == 'Linux':
             link = "https://raw.githubusercontent.com/Linuxbrew/install/master/install"
 
-        cmd = """hash brew || {{
-              ruby -e "$(curl -fsSL {0})"
-              brew update
-            }}""".format(link)
+        cmd = """hash brew || ruby -e "$(curl -fsSL {0})";
+              brew update""".format(link)
         self._bootstrap(cmd)
 
     def _bootstrap_cask(self):

--- a/brew.py
+++ b/brew.py
@@ -40,8 +40,8 @@ class Brew(dotbot.Plugin):
                 stdout = None
             if defaults.get('stderr', False) == True:
                 stderr = None
-            subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr,
-                            cwd=self._context.base_directory())
+            return subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr,
+                                   cwd=self._context.base_directory())
 
     def _tap(self, tap_list, defaults):
         if defaults.get(self._autoBootstrapOption, True) == True:
@@ -115,6 +115,7 @@ class Brew(dotbot.Plugin):
             if result != 0:
                 log.warning('Failed to install file [%s]' % f)
                 return False
+        return True
 
     def _installBrew(self, components):
         log = self._log
@@ -131,7 +132,8 @@ class Brew(dotbot.Plugin):
     def _bootstrap_brew(self):
         self._log.info("Installing brew")
         link = "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
-        cmd = """[[ $(command -v brew) != "" ]] || /bin/bash -c "$(curl -fsSL {0})" """.format(link)
+        cmd = """[[ $(command -v brew) != "" ]] || /bin/bash -c "$(curl -fsSL {0})" """.format(
+            link)
         return subprocess.call(cmd, shell=True, cwd=self._context.base_directory()) == 0
 
     def _bootstrap_cask(self):

--- a/brew.py
+++ b/brew.py
@@ -78,7 +78,7 @@ class Brew(dotbot.Plugin):
                 result = subprocess.call(cmd, shell=True, cwd=cwd)
 
                 if result != 0:
-                    log.warning('Failed to install file [%s]' % tap)
+                    log.warning('Failed to install file [%s]' % f)
                     return False
             return True
 

--- a/brew.py
+++ b/brew.py
@@ -107,7 +107,6 @@ class Brew(dotbot.Plugin):
         if defaults.get(self._autoBootstrapOption, True) == True:
             self._bootstrap_brew()
             self._bootstrap_cask()
-        stdin = stdout = stderr = devnull
         for f in brew_files:
             log.info("Installing from file %s" % f)
             cmd = "brew bundle --verbose --file=%s" % f

--- a/example.yaml
+++ b/example.yaml
@@ -1,21 +1,21 @@
 - defaults:
-  brew: 
-    auto_bootstrap: false
-    stdin: true
-    stderr: true
-    stdout: true
+    brew: 
+        auto_bootstrap: false
+        stdin: true
+        stderr: true
+        stdout: true
 
-  cask: 
-    auto_bootstrap: false
-    stdin: true
-    stderr: true
-    stdout: true
+    cask: 
+        auto_bootstrap: false
+        stdin: true
+        stderr: true
+        stdout: true
 
-  brewfile: 
-    auto_bootstrap: false
-    stdin: true
-    stderr: true
-    stdout: true
+    brewfile: 
+        auto_bootstrap: false
+        stdin: true
+        stderr: true
+        stdout: true
 
 - installBrew:
     - brew

--- a/test
+++ b/test
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+packages="$1"
+dotfiles=$(mktemp -d)
+
+cd "$dotfiles" && {
+  git init
+  git submodule add https://github.com/anishathalye/dotbot
+  git submodule add https://github.com/d12frosted/dotbot-brew.git
+
+  git config -f .gitmodules submodule.dotbot.ignore dirty
+
+  # copy install script
+  cp dotbot/tools/git-submodule/install .
+
+  # patch installation to support dotbot-brew
+  sed -i -e "s/-c/--plugin-dir dotbot-brew -c/g" "install"
+
+  echo "- brew: [$packages]" > install.conf.yaml
+
+  ./install
+}

--- a/test
+++ b/test
@@ -25,11 +25,35 @@ cd "$dotfiles" && {
   echo 'cask "$caskBrewfile"' >> Brewfile
   echo 'brew "$brewBrewfile"' >> Brewfile
 
-  echo -n > install.conf.yaml
-  echo "- installBrew: [brew, cask]" >> install.conf.yaml
-  echo "- brew: [$package]" >> install.conf.yaml
-  echo "- cask: [$cask]" >> install.conf.yaml
-  echo "- brewfile: [Brewfile]" >> install.conf.yaml
+  echo "
+- defaults:
+  brew: 
+    auto_bootstrap: false
+    stdin: true
+    stderr: true
+    stdout: true
+
+  cask: 
+    auto_bootstrap: false
+    stdin: true
+    stderr: true
+    stdout: true
+
+  brewfile: 
+    auto_bootstrap: false
+    stdin: true
+    stderr: true
+    stdout: true
+
+- brewfile: 
+  - Brewfile
+
+- brew:
+  - $package
+
+- cask:
+  - $cask
+" > install.conf.yaml
 
   ./install --verbose
 }

--- a/test
+++ b/test
@@ -2,6 +2,9 @@
 
 package="$1"
 cask="$2"
+brewBrewfile="$3"
+tapBrewfile="$4"
+caskBrewfile="$5"
 dotfiles=$(mktemp -d)
 
 cd "$dotfiles" && {
@@ -18,12 +21,15 @@ cd "$dotfiles" && {
   sed -i -e "s/-c/--plugin-dir dotbot-brew -c/g" "install"
 
   echo -n > Brewfile
-  echo "brew vim" >> Brewfile
+  echo 'tap "$tapBrewfile"' >> Brewfile
+  echo 'cask "$caskBrewfile"' >> Brewfile
+  echo 'brew "$brewBrewfile"' >> Brewfile
 
   echo -n > install.conf.yaml
+  echo "- installBrew: [brew, cask]" >> install.conf.yaml
   echo "- brew: [$package]" >> install.conf.yaml
   echo "- cask: [$cask]" >> install.conf.yaml
-  echo "- brewfile: ['Brewfile']"
+  echo "- brewfile: [Brewfile]" >> install.conf.yaml
 
-  ./install
+  ./install --verbose
 }

--- a/test
+++ b/test
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-packages="$1"
+package="$1"
+cask="$2"
 dotfiles=$(mktemp -d)
 
 cd "$dotfiles" && {
@@ -16,7 +17,9 @@ cd "$dotfiles" && {
   # patch installation to support dotbot-brew
   sed -i -e "s/-c/--plugin-dir dotbot-brew -c/g" "install"
 
-  echo "- brew: [$packages]" > install.conf.yaml
+  echo -n > install.conf.yaml
+  echo "- brew: [$package]" >> install.conf.yaml
+  echo "- cask: [$cask]" >> install.conf.yaml
 
   ./install
 }

--- a/test
+++ b/test
@@ -30,7 +30,4 @@ cd "$dotfiles" && {
 
   echo "install all packages"
   ./install --verbose
-
-  echo "make sure that one of the packages was properly installed"
-  brew test ag
 }

--- a/test
+++ b/test
@@ -17,9 +17,13 @@ cd "$dotfiles" && {
   # patch installation to support dotbot-brew
   sed -i -e "s/-c/--plugin-dir dotbot-brew -c/g" "install"
 
+  echo -n > Brewfile
+  echo "brew vim" >> Brewfile
+
   echo -n > install.conf.yaml
   echo "- brew: [$package]" >> install.conf.yaml
   echo "- cask: [$cask]" >> install.conf.yaml
+  echo "- brewfile: ['Brewfile']"
 
   ./install
 }

--- a/test
+++ b/test
@@ -29,7 +29,7 @@ cd "$dotfiles" && {
   cat install.conf.yaml
 
   echo "install all packages"
-  ./install
+  ./install --verbose
 
   echo "make sure that one of the packages was properly installed"
   brew test ag


### PR DESCRIPTION
This is a large PR, sorry, but I found a lot of issues that need fixing:

- Adds defaults for silencing or enabling `stdin`, `stderr`, `stdout`.
- Adds defaults for disabling auto bootstrapping (installing brew and cask) on any commands (those take a lot of time, and actually break with sending stdin/stderr/stdout to `/dev/null` since these may require sudoing)
- Adds `installBrew` directive (with options for `- brew` and `- cask` to work around auto bootstrapping.
- Updated the installer for brew to the new bash-based version
- Updated cask commands to the new `--cask` syntax, brew does not support the old `brew cask ls` or `brew cask install`
  -  this also fixes the tests that are currently broken.

For compatibility's sake I made sure the defaults were chosen in a way that it wouldn't break current users.

Fixes #19, #20