### PR TITLE
(ci) cover all directives in tests

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -11,10 +11,6 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v1
-
-      - name: Install some package
-        run: ./test emacs vlc
-
-      - name: Test installed package
-        run: brew test emacs
+      - uses: actions/checkout@v2
+      - name: Install some packages
+        run: ./test

--- a/Brewfile-example
+++ b/Brewfile-example
@@ -1,0 +1,2 @@
+brew "jq"
+cask "firefox"

--- a/README.org
+++ b/README.org
@@ -1,4 +1,7 @@
 * Dotbot =brew= plugin
+:PROPERTIES:
+:ID:                     52d1c964-770e-4844-8ab4-2f7f395d97c7
+:END:
 
 Plugin for [[https://github.com/anishathalye/dotbot][dotbot]] that adds =brew= and =cask= directives. It allows installation of
 packages using =brew= and =brew cask= on OS X. In case =brew= is not installed, it
@@ -6,6 +9,9 @@ will be automatically loaded and configured. The plugin itself is pretty silly
 as it doesn't handle updates and fails on unsupported operating systems.
 
 ** Installation
+:PROPERTIES:
+:ID:                     597691cd-5651-400f-ada0-a68454d7825a
+:END:
 
 Just add it as submodule of your dotfiles repository.
 
@@ -20,6 +26,9 @@ Modify your =install= script, so it automatically enables =brew= plugin.
 #+END_SRC
 
 ** Usage
+:PROPERTIES:
+:ID:                     2e816835-29cf-4747-8d19-9db69717f515
+:END:
 
 In your =install.conf.yaml= use =brew= directive to list all packages to be
 installed using =brew=. The same works with =cask= and =brewfile=. For example:

--- a/brew.py
+++ b/brew.py
@@ -18,7 +18,7 @@ class Brew(dotbot.Plugin):
             return self._process_data("brew install", data)
         if directive == self._caskDirective:
             self._bootstrap_cask()
-            return self._process_data("brew cask install", data)
+            return self._process_data("brew install --cask", data)
         if directive == self._brewFileDirective:
             self._bootstrap_brew()
             self._bootstrap_cask()
@@ -33,7 +33,7 @@ class Brew(dotbot.Plugin):
             for tap in tap_list:
                 log.info("Tapping %s" % tap)
                 cmd = "brew tap %s" % (tap)
-                result = subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd)
+                result = subprocess.call(cmd, shell=True, cwd=cwd)
 
                 if result != 0:
                     log.warning('Failed to tap [%s]' % tap)
@@ -62,7 +62,7 @@ class Brew(dotbot.Plugin):
                 if isInstalled != 0:
                     log.info("Installing %s" % package)
                     cmd = "%s %s" % (install_cmd, package)
-                    result = subprocess.call(cmd, shell=True, stdin=stdin, stdout=stdout, stderr=stderr, cwd=cwd)
+                    result = subprocess.call(cmd, shell=True, cwd=cwd)
                     if result != 0:
                         log.warning('Failed to install [%s]' % package)
                         return False

--- a/example.yaml
+++ b/example.yaml
@@ -1,11 +1,13 @@
+- brewfile:
+    - Brewfile-example
+
 - tap:
-  - caskroom/fonts
+    - homebrew/cask-fonts
 
 - brew:
     - git
-    - git-lfs
-    - emacs --with-cocoa --with-gnutls --with-librsvg --with-imagemagick --HEAD --use-git-head
+    - bash
 
-- brew: [gnupg, gnupg2]
+- brew: [ack, ag]
 
-- cask: [colorpicker, vlc]
+- cask: [gpg-suite, vlc]

--- a/test
+++ b/test
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
 
-package="$1"
-cask="$2"
+set -e
+
+echo "create a temporary dotfiles directory at $dotfiles"
 dotfiles=$(mktemp -d)
 
+echo "copy install configurations"
+cp "example.yaml" "$dotfiles/install.conf.yaml"
+cp "Brewfile-example" "$dotfiles/Brewfile-example"
+
+echo "copy dotbot-brew"
+cp -r "." "$dotfiles/dotbot-brew"
+
 cd "$dotfiles" && {
+  echo "initialize repository"
   git init
   git submodule add https://github.com/anishathalye/dotbot
-  git submodule add https://github.com/d12frosted/dotbot-brew.git
 
   git config -f .gitmodules submodule.dotbot.ignore dirty
 
-  # copy install script
+  echo "copy install script"
   cp dotbot/tools/git-submodule/install .
 
-  # patch installation to support dotbot-brew
+  echo "patch installation to support dotbot-brew"
   sed -i -e "s/-c/--plugin-dir dotbot-brew -c/g" "install"
 
-  echo -n > install.conf.yaml
-  echo "- brew: [$package]" >> install.conf.yaml
-  echo "- cask: [$cask]" >> install.conf.yaml
+  echo "content of install.conf.yaml"
+  cat install.conf.yaml
 
+  echo "install all packages"
   ./install
+
+  echo "make sure that one of the packages was properly installed"
+  brew test ag
 }


### PR DESCRIPTION
1. stop using deprecated `brew cask install` to install cask packages,
   instead use `brew install --cask`;
2. be verbose during installation, so any error due to
   misconfiguration is not silently gulped and instead presented to
   the user;
3. use local version of `dotbot-brew`, instead of pulling from master,
   meaning that any changes to plugin are actually tested;
4. test all directives instead of two.