### PR TITLE
Support single directive in yaml

### DIFF
--- a/brew.py
+++ b/brew.py
@@ -10,6 +10,8 @@ class Brew(dotbot.Plugin):
         return directive in (self._tapDirective, self._brewDirective, self._caskDirective, self._brewFileDirective)
 
     def handle(self, directive, data):
+        if isinstance(data, str):
+            data = [data]
         if directive == self._tapDirective:
             self._bootstrap_brew()
             return self._tap(data)


### PR DESCRIPTION
When `install.conf.yaml` has just one directive with one  value, the `handle` function reads the `data` variable as a string instead of a list of strings. In this case, the downstream functions convert the string into a list of characters and wrongly try to install brew packages with single-character names.