### PR TITLE
dev: update linux example

### DIFF
--- a/examples/linux/example.yaml
+++ b/examples/linux/example.yaml
@@ -2,7 +2,7 @@
     - Brewfile
 
 - tap:
-    - homebrew/cask-fonts
+    - d12frosted/emacs-plus
 
 - brew:
     - git


### PR DESCRIPTION
fonts tap is deprecated anyways - hence the failing test not that I care